### PR TITLE
Test caches for linked resources

### DIFF
--- a/src/type.coffee
+++ b/src/type.coffee
@@ -48,7 +48,7 @@ module.exports = class Type extends Emitter
 
   _getByIDs: (ids, otherArgs...) ->
     requests = for id in ids
-      if id of @_resourcesCache and otherArgs.length is 0
+      if id of @_resourcesCache and (otherArgs.length is 0 or not otherArgs[0]?)
         Promise.resolve @_resourcesCache[id]
       else
         @_client.get(@_getURL(id), otherArgs...).then ([resource]) ->


### PR DESCRIPTION
Make sure linked resources are being loaded from resources caches if
they exist.

Some links are only defined by a URL so this double caches resources by
id and by their href element if it exists. This takes care of caching
avatars if they're queried for using ?include=avatar

Previously the code to fetch a linked resource was busting the resource
cache by passing an additional non-ID argument 'query' that was usually
undefined. This forced the client to re-request for the resource instead
of loading it from the cache by id.